### PR TITLE
ADDED: TravisCI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+sudo: required
+
+language: dockerfile
+
+services:
+  - docker
+
+before_install:
+  - make build
+
+script:
+  - make test


### PR DESCRIPTION
Add the TravisCI configuration to test the docker build process.
I'm opening the PR because I have to test if the _configuration_ is OK and may also need some help if I don't have the rights over the organization to allow Travis to access to this repository